### PR TITLE
Add testpilot module to go.jetify.com

### DIFF
--- a/axiom/testpilot/index.html
+++ b/axiom/testpilot/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <title>go.jetify.com/axiom/testpilot</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <meta name="go-import" content="go.jetify.com/axiom git https://github.com/jetify-com/axiom">
+    <meta http-equiv="refresh" content="0; url=https://github.com/jetify-com/axiom">
+</head>
+
+<body>
+    Redirecting to <a href="https://github.com/jetify-com/axiom">github.com/jetify-com/axiom</a>
+</body>
+
+</html>

--- a/gen.sh
+++ b/gen.sh
@@ -38,6 +38,7 @@ module axiom axiom api        # go.jetify.com/axiom/api
 module axiom axiom launchpad  # go.jetify.com/axiom/launchpad
 module axiom axiom opensource # go.jetify.com/axiom/opensource
 module axiom axiom pkg        # go.jetify.com/axiom/pkg
+module axiom axiom testpilot  # go.jetify.com/axiom/testpilot
 module devbox                 # go.jetify.com/devbox
 module envsec                 # go.jetify.com/envsec
 module launchpad              # go.jetify.com/launchpad


### PR DESCRIPTION
Add testpilot as a module in `go.jetify.com` – probably the reason `tidy` has been failing for you.