### PR TITLE
Add ai repo to go.jetify.com

### DIFF
--- a/ai/index.html
+++ b/ai/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <title>go.jetify.com/ai</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <meta name="go-import" content="go.jetify.com/ai git https://github.com/jetify-com/ai">
+    <meta http-equiv="refresh" content="0; url=https://github.com/jetify-com/ai">
+</head>
+
+<body>
+    Redirecting to <a href="https://github.com/jetify-com/ai">github.com/jetify-com/ai</a>
+</body>
+
+</html>

--- a/gen.sh
+++ b/gen.sh
@@ -31,6 +31,7 @@ module() {
 
 # module <repo_name> [module_root] [module_subdir]
 
+module ai                     # go.jetify.com/ai
 # The axiom root is not a real module, but it's needed to make modules in
 # subdirectories work.
 module axiom                  # go.jetify.com/axiom


### PR DESCRIPTION
Expose the new AI repo under go.jellify.com. 